### PR TITLE
Rename submitter name and 'username' honeypot fields

### DIFF
--- a/application_form/apply.php
+++ b/application_form/apply.php
@@ -43,8 +43,8 @@ $hashed_time = $hashids->encode(time());
     <form id="request_form" action="rooms.php" method="post" enctype="multipart/form-data" class="form">
       <input type="hidden" name="formLoaded3fk7sa11" value="<?php echo $hashed_time; ?>" />
       <div class="form-group">
-        <label for="submitter_name" class="control-label required">Your name</label>
-        <input type="text" class="form-control" name="submitter_name" value="" required>
+        <label for="your_name" class="control-label required">Your name</label>
+        <input type="text" class="form-control" name="your_name" value="" required>
       </div>
       <div class="form-group">
         <label for="submitter_email" class="control-label required">Your email</label>
@@ -60,8 +60,8 @@ $hashed_time = $hashids->encode(time());
         <input type="text" class="form-control" name="title" value="" required>
       </div>
       <div class="form-group de-visual" aria-hidden="true">
-        <label for="username" class="control-label required">Username</label>
-        <input type="text" class="form-control" name="username" value="" placeholder="Leave this field blank" autocomplete="off">
+        <label for="submitter_name" class="control-label required">Submitter name</label>
+        <input type="text" class="form-control" name="submitter_name" value="" placeholder="Leave this field blank" autocomplete="off">
       </div>
       <div class="form-group">
         <label for="sponsor" class="control-label">Sponsoring group/department</label>

--- a/application_form/rooms.php
+++ b/application_form/rooms.php
@@ -10,7 +10,7 @@ $timestamp = $hashids->decode($_POST['formLoaded3fk7sa11']);
 
 // Check honeypot and timestamp. The timestamp must be at least 15 seconds in the past -
 // otherwise it's safe to assume that a bot submitted the form.
-if ($_POST['username'] || (time() - (int)join('',$timestamp) < 15)) {
+if ($_POST['submitter_name'] || (time() - (int)join('',$timestamp) < 15)) {
   $timestamp = date("Y-m-d H:i", time());
   file_put_contents('spam_log', "Blocked suspected spam at $timestamp: " . $_POST['event_description'], FILE_APPEND);
   header( 'Location: rooms.html' );
@@ -25,7 +25,7 @@ $text .= title('General Information');
 # title
 $text .= add_text('title');
 # email
-$text .= 'submitted by: ' . $_POST['submitter_name'] . ' (' . $_POST['submitter_email'] . ")\n";
+$text .= 'submitted by: ' . $_POST['your_name'] . ' (' . $_POST['submitter_email'] . ")\n";
 #phone
 $text .= 'phone number: ' . $_POST['submitter_phone'] . "\n";
 # sponsor
@@ -268,7 +268,7 @@ $issueData = array('project' => $project,
                                             array('field' => array('id' => 4),
                                                   'value' => $dateToPost),
                                             array('field' => array('id' => 6),
-                                                  'value' => $_POST['submitter_name'])));
+                                                  'value' => $_POST['your_name'])));
 $newIssueId = $client->mc_issue_add($cul_ini_array['api_user'], $cul_ini_array['api_pass'], $issueData);
 
 # Handle attachments


### PR DESCRIPTION
If spammers have already latched on to our form, they may not even
notice the new honeypot field. By renaming one of the previously
valid fields (submitter_name) and using that as a honeypot field instead,
we may be able to trip them up.